### PR TITLE
ports/stm32/gccollect.c: dont assume end of stack == end of RAM

### DIFF
--- a/ports/stm32/gccollect.c
+++ b/ports/stm32/gccollect.c
@@ -52,7 +52,7 @@ void gc_collect(void) {
     #if MICROPY_PY_THREAD
     gc_collect_root((void**)sp, ((uint32_t)MP_STATE_THREAD(stack_top) - sp) / sizeof(uint32_t));
     #else
-    gc_collect_root((void**)sp, ((uint32_t)&_ram_end - sp) / sizeof(uint32_t));
+    gc_collect_root((void**)sp, ((uint32_t)&_estack - sp) / sizeof(uint32_t));
     #endif
 
     // trace root pointers from any threads


### PR DESCRIPTION
I have moved the stack into SRAM2 with heap remaining in SRAM1, and so I hit this bug.

This line calculates the depth of the stack, and it should only consider `_estack` and not `_ram_end`.

All the existing ports for `stm32` have their stack at the end of memory, so `_ram_end` does equal `_estack`. Change should not affect them, but it's critical for my board.

```sh
[ports/stm32 33] egrep '(ram_end|estack)' */*.ld
boards/stm32f091xc.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f091xc.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f401xd.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f401xd.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f401xe.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f401xe.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f405.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f405.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f411.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f411.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f429.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f429.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f439.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f439.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f746.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f746.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f767.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f767.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f769.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32f769.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32h743.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32h743.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32l476xe.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32l476xe.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32l476xg.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32l476xg.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM);
boards/stm32l496xg.ld:_estack = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2);
boards/stm32l496xg.ld:_ram_end = ORIGIN(RAM) + LENGTH(RAM) + LENGTH(SRAM2);
mboot/stm32_generic.ld:_estack = ORIGIN(RAM) + LENGTH(RAM);
```