### PR TITLE
suppress btree warnings when compiling the unix port on macOS

### DIFF
--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -225,7 +225,7 @@ SRC_MOD += $(addprefix $(BTREE_DIR)/,\
 CFLAGS_MOD += -DMICROPY_PY_BTREE=1
 # we need to suppress certain warnings to get berkeley-db to compile cleanly
 # and we have separate BTREE_DEFS so the definitions don't interfere with other source code
-$(BUILD)/$(BTREE_DIR)/%.o: CFLAGS += -Wno-old-style-definition -Wno-sign-compare -Wno-unused-parameter $(BTREE_DEFS)
+$(BUILD)/$(BTREE_DIR)/%.o: CFLAGS += -Wno-old-style-definition -Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-non-prototype -Wno-unknown-warning-option $(BTREE_DEFS)
 $(BUILD)/extmod/modbtree.o: CFLAGS += $(BTREE_DEFS)
 endif
 


### PR DESCRIPTION
https://github.com/micropython/micropython/pull/11510