### PR TITLE
fix pydfu.py script compat

### DIFF
--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -82,7 +82,7 @@ __DFU_INTERFACE = 0
 import inspect
 # Python 3 deprecated getargspec in favour of getfullargspec, but
 # Python 2 doesn't have the latter, so detect which one to use
-getargspec = getattr(inspect, "getfullargspec", inspect.getargspec)
+getargspec = getattr(inspect, "getfullargspec", getattr(inspect, "getargspec", None))
 
 if "length" in getargspec(usb.util.get_string).args:
     # PyUSB 1.0.0.b1 has the length argument


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/scg/PycharmProjects/firmware/stm32/../external/micropython/tools/pydfu.py", line 85, in <module>
    getargspec = getattr(inspect, "getfullargspec", inspect.getargspec)
                                                    ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
```