### PR TITLE
use github mirror instead of savannah.org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	url = https://github.com/atgreen/libffi
 [submodule "lib/lwip"]
 	path = lib/lwip
-	url = https://git.savannah.gnu.org/r/lwip.git
+	url = https://github.com/lwip-tcpip/lwip.git
 [submodule "lib/berkeley-db-1.xx"]
 	path = lib/berkeley-db-1.xx
 	url = https://github.com/pfalcon/berkeley-db-1.xx


### PR DESCRIPTION
* not sure if it is just temporary, but I'm unable to fetch it from old URL
`fatal: unable to access 'https://git.savannah.gnu.org/r/lwip.git/': Failed to connect to git.savannah.gnu.org port 443 after 132949 ms: Couldn't connect to server` 
* micropython uses the mirror too https://github.com/micropython/micropython/blob/8c47e446bf99393fd20c0416970f5c9a78b294f7/.gitmodules#L9